### PR TITLE
Fix digital poster links

### DIFF
--- a/_data/portfolio.yml
+++ b/_data/portfolio.yml
@@ -17,17 +17,17 @@ en:
   - title: Digital Poster (DE)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-23-B2-final-ayce-german.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-german.pdf
 
   - title: Digital Poster (FR)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-23-B2-final-ayce-french.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-french.pdf
 
   - title: Digital Poster (EN)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-22-B2-final-ayce-english.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-english.pdf
 
   - title: One CO₂ Poster SE
     category:  Greenpeace Schweiz Special Edition
@@ -54,17 +54,17 @@ de:
   - title: Digital Poster (DE)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-23-B2-final-ayce-german.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-german.pdf
 
   - title: Digital Poster (FR)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-23-B2-final-ayce-french.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-french.pdf
 
   - title: Digital Poster (EN)
     category: for free
     image: /assets/images/portfolio/Food-Poster-Mockup-digital.jpg
-    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-06-22-B2-final-ayce-english.pdf
+    link: https://github.com/AYCE-earth/public/releases/download/v1.6.1/2023-07-03-B2-final-ayce-english.pdf
 
   - title: Ein CO₂ Poster
     category:  Greenpeace Schweiz Special Edition 


### PR DESCRIPTION
With release 1.6.1 the links on https://ayce.earth to the digital posters have gone dead. This should fix it.